### PR TITLE
closes #17 FINALLY GOT IT WORKING

### DIFF
--- a/public/spec/apiSpec.js
+++ b/public/spec/apiSpec.js
@@ -1,23 +1,26 @@
 "use strict";
 
 describe("getURL", function(){
-
-  var url = 'http://localhost:8080/sample_data.json'
+  var url = testUrl();
+  
   it("is able to connect to the server", function(){
     getURL(url, function(){
       expect(this.status).toEqual(200);
     });
-  })
+  });
+  
   it("contains 'UK News'", function() {
     getURL(url, function(){
       expect(this.responseText).toContain("UK news")
     });
-  })
-})
+  });
+});
 
 describe("guardianApi", function(){
+  var url = testUrl();
+  
   it("it is able to return a news article using API", function(){
-    guardianApi("http://localhost:8080/sample_data.json");
+    guardianApi(url);
     // this is a messy test and needs refactoring
     expect(results()[3].webTitle).toContain("Giggs and Neville skyscrapers 'threaten Manchester's heritage'");
   });

--- a/public/spec/helpers/userHelper.js
+++ b/public/spec/helpers/userHelper.js
@@ -1,0 +1,33 @@
+"use strict";
+
+(function(exports) {
+  // Maybe there's a better place to store these urls? 
+  var cloud9SampleUrl = "https://ruby-learning-benjcarson.c9users.io/Projects/7week/news-app/public/sample_data.json";
+  var localHostUrl = "http://localhost:8080/sample_data.json";
+  var returnUrl = localHostUrl;
+  
+  function _userCloud9(bool) {
+    if(bool) { returnUrl = cloud9SampleUrl }
+  }
+
+  function userCheck() {
+    var errorMessage = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '"+localHostUrl+"'.";
+    
+    try {
+      getURL(localHostUrl, function(){});
+    }
+    catch(error) {
+      if(error.message === errorMessage) {
+        _userCloud9(true);
+      }
+    }
+  }
+  
+  function testUrl() {
+    userCheck();
+    return returnUrl;
+  }
+  
+  exports.userCheck = userCheck;
+  exports.testUrl = testUrl;
+})(this);

--- a/public/specRunner.html
+++ b/public/specRunner.html
@@ -11,6 +11,7 @@
     <script src="src/api.js" defer></script>
 
     <!-- Spec files -->
+    <script src="spec/helpers/userHelper.js" defer></script>
     <script src="spec/apiSpec.js" defer></script>
   </head>
   <body>


### PR DESCRIPTION
This took far too much time to implement. Shouldn't break anything, all it does when you call ```testUrl()``` is checks if doing a get request to localhost:8080... throws a particular error or not. If it does (which it will on cloud9) then it automatically returns the url I need for cloud9. Otherwise it defaults to localhost. Pretty sure there's a better way to store the urls than in the module, but messing with ENV is a bit beyond me this evening